### PR TITLE
Handle mobileconfig display names with special characters

### DIFF
--- a/data/web/mobileconfig.php
+++ b/data/web/mobileconfig.php
@@ -22,7 +22,7 @@ try {
   $stmt = $pdo->prepare("SELECT `name` FROM `mailbox` WHERE `username`= :username");
   $stmt->execute(array(':username' => $email));
   $MailboxData = $stmt->fetch(PDO::FETCH_ASSOC);
-  $displayname = empty($MailboxData['name']) ? $email : $MailboxData['name'];
+  $displayname = htmlspecialchars(empty($MailboxData['name']) ? $email : $MailboxData['name']);
 }
 catch(PDOException $e) {
   $displayname = $email;

--- a/data/web/mobileconfig.php
+++ b/data/web/mobileconfig.php
@@ -22,7 +22,7 @@ try {
   $stmt = $pdo->prepare("SELECT `name` FROM `mailbox` WHERE `username`= :username");
   $stmt->execute(array(':username' => $email));
   $MailboxData = $stmt->fetch(PDO::FETCH_ASSOC);
-  $displayname = htmlspecialchars(empty($MailboxData['name']) ? $email : $MailboxData['name']);
+  $displayname = htmlspecialchars(empty($MailboxData['name']) ? $email : $MailboxData['name'], ENT_NOQUOTES);
 }
 catch(PDOException $e) {
   $displayname = $email;


### PR DESCRIPTION
If the account display name contained special characters like & the mobileconfig would fail to import on the iOS device.